### PR TITLE
Automatically update Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Automatically update base images in Dockerfiles if available
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: "daily"
+  # Also automatically update any Github Actions used in the workflow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+name: Build Docker images
+
+on:
+  # Allow manual runs.
+  workflow_dispatch:
+  # Also run on updates to this repo.
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+  # Run on PRs except for documentation.
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+  
+env:
+  IMAGE_NAME: starbound-server
+  # This doesn't apply to Starbound but to build a multi-arch Docker image you can
+  # set multiple platforms like this:
+  # PLATFORMS: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
+  PLATFORMS: linux/amd64
+  # Only push the image on merges to main
+  PUSH_IMAGE: ${{ github.ref == 'refs/heads/master' }}
+
+jobs:
+
+  build-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set datestamp for image tagging
+        run: |
+          echo DATESTAMP=$(date +%Y.%m.%d) >> $GITHUB_ENV
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push ${{ env.IMAGE_NAME }} Docker image
+        uses: docker/build-push-action@v2
+        with:
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME || 'nobody' }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME || 'nobody' }}/${{ env.IMAGE_NAME }}:v${{ env.DATESTAMP }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:v${{ env.DATESTAMP }}
+          platforms: ${{ env.PLATFORMS }}
+          push: ${{ env.PUSH_IMAGE }}


### PR DESCRIPTION
This change is twofold:

- I've added a `dependabot.yml` to make GitHub's Dependabot automatically update the base image in the Dockerfile when a new version becomes available
- I've also added a GitHub workflow which will automatically build (and, on commits to `master`, push) a new Docker image for the server, tagged both as `latest` and with a semver-compatible date stamp.

For the CI workflow to function, the repository will need three secrets set:
- `DOCKERHUB_USERNAME` for the user/org name to push the image to `hub.docker.com` under (i.e. `didstopia` in this case)
- `DOCKERHUB_TOKEN` as a PAT to your Docker Hub account so that the image can be pushed
- `GHCR_TOKEN` as a PAT to your GitHub account with the `delete:packages`, `repo` and `write:packages` scopes so the image can also be pushed to the GitHub container registry. I've added this as Docker Hub has started introducing restrictions, and pushing the image to GHCR as well as Docker Hub is no extra effort while making the image more widely available.

I'm using this workflow with minimal changes widely across my own Docker image repositories, hence the configurability - you'll notice some commented-out steps and variables that would allow building of multi-arch images which don't apply here since Steam and Starbound are only available on x86, but I'm e.g. using the workflow in its full form to build [multi-arch ioquake3 server images](https://github.com/fpiesche/docker-ioquake3-server/).