### PR TITLE
Simplify build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         if: ${{ env.PUSH_IMAGE == 'true' }}
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: didstopia
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,6 @@ on:
       - '**/*.md'
   
 env:
-  IMAGE_NAME: starbound-server
-  # This doesn't apply to Starbound but to build a multi-arch Docker image you can
-  # set multiple platforms like this:
-  # PLATFORMS: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
-  PLATFORMS: linux/amd64
   # Only push the image on merges to main
   PUSH_IMAGE: ${{ github.ref == 'refs/heads/master' }}
 
@@ -29,14 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set datestamp for image tagging
         run: |
           echo DATESTAMP=$(date +%Y.%m.%d) >> $GITHUB_ENV
-
-      - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v1
 
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v1
@@ -56,13 +48,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Build and push ${{ env.IMAGE_NAME }} Docker image
+      - name: Build and push `starbound-server` Docker image
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME || 'nobody' }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME || 'nobody' }}/${{ env.IMAGE_NAME }}:v${{ env.DATESTAMP }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:v${{ env.DATESTAMP }}
-          platforms: ${{ env.PLATFORMS }}
+            didstopia/starbound-server:latest
+            didstopia/starbound-server:v${{ env.DATESTAMP }}
+            ghcr.io/didstopia/starbound-server:latest
+            ghcr.io/didstopia/starbound-server:v${{ env.DATESTAMP }}
+          platforms: linux/amd64
           push: ${{ env.PUSH_IMAGE }}


### PR DESCRIPTION
Got another one for you!

This change makes the GitHub Actions workflow more readable by removing a bunch of the variables, and also fixes building and pushing Docker images - on my original PR this was simply using the GitHub repository owner as the repository name, but as your GitHub user name contains an upper-case D this was failing as Docker repository names must be all lowercase.

If you didn't do this after my previous PR, you will need to add a couple of secrets to this repo (at https://github.com/Didstopia/starbound-server/settings/secrets/actions):

  - A secret called `GHCR_TOKEN` with its value set to a GitHub Personal Access Token for your account (you can create this at https://github.com/settings/tokens/new) with scope permissions set to `write:packages` (and `read:packages` which is included in this). I would recommend setting it to never expire as otherwise you'll have to periodically update/re-create it for the workflow to continue working.
  - A secret called `DOCKERHUB_TOKEN` with its value set to a Docker Hub access token; you can create this at https://hub.docker.com/settings/security. The token will need `read` and `write` access in order to push new images.